### PR TITLE
chore: 0.65 TON for jetton transfer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   internal,
   Dictionary,
   loadMessageRelaxed,
+  toNano,
 } from "@ton/ton";
 import {
   multisigConfigToCell,
@@ -122,7 +123,7 @@ function jettonTransferAction(
 
   const msg = internal({
     to: jettonWalletAddress,
-    value: estimateJettonTransferFee(forwardTonAmount),
+    value: toNano("0.65"), // TODO: should use `estimateJettonTransferFee(forwardTonAmount)`,
     body: body.endCell(),
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated jetton transfer fee calculation to use a fixed value of 0.65 TON instead of dynamically estimating the fee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->